### PR TITLE
Updated mkdir exception handling in extract_mask_shared.py

### DIFF
--- a/three_steps_3d_feature/first_step/extract_mask_shared.py
+++ b/three_steps_3d_feature/first_step/extract_mask_shared.py
@@ -44,16 +44,10 @@ if __name__ == '__main__':
     scene_dir = args.scene_dir_path
     save_dir = args.save_dir_path
 
-    try:
-        os.mkdir(os.path.join(save_dir))
-    except:
-        pass
+    os.makedirs(save_dir, exist_ok=True)
 
     for scan in tqdm(os.listdir(scene_dir)):
-        try:
-            os.mkdir(os.path.join(save_dir, scan))
-        except:
-            pass
+        os.makedirs(os.path.join(save_dir, scan), exist_ok=True)
         
         rgb_list = glob.glob(os.path.join(scene_dir, scan, "*png"))
 


### PR DESCRIPTION
The os.mkdir function will raise an exception if the directory already exists.  os.makedirs(... , exist_ok=True), has the same effect but doesn't raise an exception if the directory already exists.