### PR TITLE
Fix blips_t5 bug on passing 'prompt' argument

### DIFF
--- a/3DLLM_BLIP2-base/lavis/models/blip2_models/blip2_t5.py
+++ b/3DLLM_BLIP2-base/lavis/models/blip2_models/blip2_t5.py
@@ -95,7 +95,7 @@ class Blip2T5(Blip2Base):
         self.pos_embedding = pos_model(x).squeeze().cuda()
 
         self.max_txt_len = max_txt_len
-        self.prompt = ""
+        self.prompt = prompt
         self._apply_lemmatizer = apply_lemmatizer
         self._lemmatizer = None
 
@@ -310,7 +310,8 @@ class Blip2T5(Blip2Base):
         prompt = self.prompt
 
         if prompt:
-            text_input = [prompt.format(question) for question in samples["text_input"]]
+            # text_input = [prompt.format(question) for question in samples["text_input"]]
+            text_input = [question + " " + prompt for question in samples["text_input"]]         # put prompt after each question    
         else:
             text_input = samples["text_input"]
 


### PR DESCRIPTION
In the original code, if I want to modify or add some prompt in yaml file, this argument cannot be passed to the blip_t5 model.
So I modified the passing of this argument in blip_t5.py and updated the code.

I've tested the new code and it works when I want to add different prompts to this model.